### PR TITLE
feat: 인증서 수정 API 모든 필드 업데이트 지원 및 모듈 구조 최적화

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,10 +3,10 @@
 .gitignore
 .gitattributes
 
-# Gradle
+# Gradle (Docker 내부에서 빌드하므로 로컬 빌드 결과물 제외)
 .gradle
 **/build
-!gradle/wrapper/gradle-wrapper.jar
+gradle-wrapper.jar.txt
 
 # IDE
 .idea
@@ -34,6 +34,7 @@ Thumbs.db
 docs
 *.md
 !README.md
+!CLAUDE.md
 
 # CI/CD
 .github
@@ -44,3 +45,14 @@ node_modules
 # Test
 **/test-results
 **/coverage
+
+# Docker 관련 (빌드 속도 향상)
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# 임시 파일
+*.tmp
+*.bak
+*.swp
+*~

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,7 @@ docker-compose down
 ### 모듈 의존성 계층 구조
 ```
 api (Application Layer - 애플리케이션 계층)
- ├─> certificate-manager
- ├─> distribution-service
+ ├─> certificate-manager (인증서 관리 및 배포)
  ├─> webserver-integration
  ├─> reload-service
  ├─> monitoring-service
@@ -114,16 +113,14 @@ api (Application Layer - 애플리케이션 계층)
 - 도메인 서비스 및 이벤트
 - Flyway 마이그레이션 (`src/main/resources/db/migration/`)
 
-**certificate-manager/** - 인증서 생명주기 관리
+**certificate-manager/** - 인증서 생명주기 관리 및 배포
 - ACME 프로토콜 통합 (Let's Encrypt, ZeroSSL)
 - DNS-01, HTTP-01 챌린지 핸들러
 - 인증서 갱신 스케줄러 (cron: "0 0 2 * * ?" - 매일 새벽 2시)
 - 인증서 타입별 갱신 전략 패턴
 - 인증서 검증 및 저장
-
-**distribution-service/** - 대상 서버로의 인증서 배포
-- sshj 라이브러리를 사용한 SSH/SFTP 파일 전송
-- 재시도 로직 (최대 3회, exponential backoff)
+- SSH/SFTP를 통한 대상 서버 인증서 배포 (sshj 라이브러리)
+- 배포 재시도 로직 (최대 3회, exponential backoff)
 - 다중 서버 병렬 배포 지원
 
 **webserver-integration/** - 웹서버 설정 통합

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY certificate-manager/src ./certificate-manager/src
 COPY api/src ./api/src
 
 # Build the application
-RUN gradle :api:bootJar --no-daemon -x test
+RUN gradle :api:bootJar --no-daemon
 
 # Runtime stage
 FROM eclipse-temurin:21-jre-alpine
@@ -38,4 +38,4 @@ ENV TZ=Asia/Seoul
 EXPOSE 8080
 
 # Run the application
-ENTRYPOINT ["java", "-Xmx1024m", "-Xms512m", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx2048m", "-Xms1024m", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ ACME 프로토콜 기반 자동 갱신 흐름
 각 서비스 모듈의 내부 구조
 
 - Certificate Manager (ACME Client, Renewal Scheduler)
-- Distribution Service (SSH Manager, Credential Vault)
 - Web Server Integration (Config Generator, Server Adapter)
-- Reload Service (Health Checker, Rollback Manager)
 - Monitoring Dashboard (Expiry Tracker, Alert Manager)
 
 #### 5. [모니터링 대시보드](mermaid/05-monitoring-dashboard.mmd)
@@ -188,28 +186,16 @@ java -jar api/build/libs/api-1.0.0-SNAPSHOT.jar
 
 ```
 auto-cert/
-├── docker/
-│   └── nginx/
-│       ├── nginx.conf                     # Nginx 메인 설정
-│       ├── conf.d/
-│       │   ├── default.conf               # localhost (활성)
-│       │   └── ctrl-ai-shop.conf.example  # 도메인 템플릿
-│       └── html/
-│           └── index.html                 # Welcome 페이지
 ├── certs/                                 # 인증서 디렉토리
 │   ├── localhost.crt                      # Self-signed
 │   ├── localhost.key
 │   └── .gitkeep                           # Git 추적용
-├── logs/
-│   └── nginx/                             # Nginx 로그
 ├── mermaid/                               # 아키텍처 다이어그램
 ├── docs/                                  # 설계 문서
 ├── common/                                # 공통 유틸리티
 ├── domain/                                # 도메인 모델
 ├── certificate-manager/                   # 인증서 관리
-├── distribution-service/                  # 배포 서비스
 ├── webserver-integration/                 # 웹서버 통합
-├── reload-service/                        # 재시작 서비스
 ├── monitoring-service/                    # 모니터링
 ├── api/                                   # API Gateway (Main)
 └── docker-compose.yml                     # Docker 설정
@@ -245,5 +231,5 @@ auto-cert/
 ---
 
 **문서 버전**: 1.1.0
-**최종 수정일**: 2025-11-15
+**최종 수정일**: 2025-11-20
 **작성자**: Auto-Cert Development Team

--- a/api/src/main/java/com/hwgi/autocert/api/dto/request/CertificateCreateRequest.java
+++ b/api/src/main/java/com/hwgi/autocert/api/dto/request/CertificateCreateRequest.java
@@ -2,6 +2,7 @@ package com.hwgi.autocert.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -13,6 +14,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CertificateCreateRequest {
+
+    @Schema(description = "서버 ID", example = "1")
+    @NotNull(message = "서버 ID는 필수입니다")
+    private Long serverId;
 
     @Schema(example = "example.com", description = "인증서를 발급받을 도메인")
     @NotBlank(message = "도메인은 필수입니다")
@@ -28,4 +33,7 @@ public class CertificateCreateRequest {
     @Schema(description = "만료 전 알림 일수 (기본값: 7일)", example = "7")
     @Min(value = 1, message = "알림 일수는 1일 이상이어야 합니다")
     private Integer alertDaysBeforeExpiry;
+
+    @Schema(description = "서버에 자동 배포 여부 (기본값: false)", example = "false")
+    private Boolean autoDeploy = false;
 }

--- a/api/src/main/java/com/hwgi/autocert/api/dto/request/CertificateUpdateRequest.java
+++ b/api/src/main/java/com/hwgi/autocert/api/dto/request/CertificateUpdateRequest.java
@@ -1,0 +1,54 @@
+package com.hwgi.autocert.api.dto.request;
+
+import com.hwgi.autocert.domain.model.CertificateStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 인증서 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class CertificateUpdateRequest {
+
+    @Schema(description = "도메인 이름")
+    private String domain;
+
+    @Schema(description = "서버 ID")
+    private Long serverId;
+
+    @Schema(description = "발급 일시")
+    private LocalDateTime issuedAt;
+
+    @Schema(description = "만료 일시")
+    private LocalDateTime expiresAt;
+
+    @Schema(description = "인증서 상태 (ACTIVE, EXPIRED, REVOKED, PENDING)")
+    private CertificateStatus status;
+
+    @Schema(description = "인증서 PEM 형식 데이터")
+    private String certificatePem;
+
+    @Schema(description = "개인키 PEM 형식 데이터")
+    private String privateKeyPem;
+
+    @Schema(description = "체인 PEM 형식 데이터")
+    private String chainPem;
+
+    @Schema(description = "인증서 비밀번호")
+    private String password;
+
+    @Schema(description = "인증서 관리자 또는 담당자")
+    private String admin;
+
+    @Schema(description = "만료 전 알림 일수", example = "7")
+    @Min(value = 1, message = "알림 일수는 1일 이상이어야 합니다")
+    private Integer alertDaysBeforeExpiry;
+
+    @Schema(description = "서버에 자동 배포 여부", example = "false")
+    private Boolean autoDeploy;
+}

--- a/api/src/main/java/com/hwgi/autocert/api/dto/response/CertificateResponse.java
+++ b/api/src/main/java/com/hwgi/autocert/api/dto/response/CertificateResponse.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 public class CertificateResponse {
 
     private Long id;
+    private Long serverId;
     private String domain;
     private String issuer;
     private LocalDateTime issuedAt;
@@ -27,6 +28,7 @@ public class CertificateResponse {
     private String lastError;
     private String admin;
     private Integer alertDaysBeforeExpiry;
+    private Boolean autoDeploy;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -36,12 +38,14 @@ public class CertificateResponse {
     public static CertificateResponse from(Certificate certificate) {
         return CertificateResponse.builder()
                 .id(certificate.getId())
+                .serverId(certificate.getServer() != null ? certificate.getServer().getId() : null)
                 .domain(certificate.getDomain())
                 .issuedAt(certificate.getIssuedAt())
                 .expiresAt(certificate.getExpiresAt())
                 .status(certificate.getStatus().name())
                 .admin(certificate.getAdmin())
                 .alertDaysBeforeExpiry(certificate.getAlertDaysBeforeExpiry())
+                .autoDeploy(certificate.getAutoDeploy())
                 .createdAt(certificate.getCreatedAt())
                 .updatedAt(certificate.getUpdatedAt())
                 .build();

--- a/certificate-manager/build.gradle
+++ b/certificate-manager/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     // Bouncy Castle (암호화)
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.78'
+
+    // SSHJ (SSH/SFTP 클라이언트 - 배포용)
+    implementation 'com.hierynomus:sshj:0.38.0'
 }
 
 // Library module - disable bootJar

--- a/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/config/DistributionProperties.java
+++ b/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/config/DistributionProperties.java
@@ -1,0 +1,52 @@
+package com.hwgi.autocert.certificate.distribution.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 배포 서비스 설정
+ */
+@Configuration
+@ConfigurationProperties(prefix = "autocert.distribution")
+@Getter
+@Setter
+public class DistributionProperties {
+
+    private Ssh ssh = new Ssh();
+
+    @Getter
+    @Setter
+    public static class Ssh {
+        /**
+         * SSH 연결 타임아웃 (밀리초)
+         */
+        private int timeout = 30000;
+
+        /**
+         * 최대 재시도 횟수
+         */
+        private int maxRetries = 3;
+
+        /**
+         * 재시도 대기 시간 (밀리초)
+         */
+        private int retryDelay = 1000;
+
+        /**
+         * SSH 포트
+         */
+        private int port = 22;
+
+        /**
+         * 인증서 기본 배포 경로
+         */
+        private String defaultCertPath = "/etc/ssl/certs";
+
+        /**
+         * 개인키 기본 배포 경로
+         */
+        private String defaultKeyPath = "/etc/ssl/private";
+    }
+}

--- a/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/service/CertificateDistributionService.java
+++ b/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/service/CertificateDistributionService.java
@@ -1,0 +1,223 @@
+package com.hwgi.autocert.certificate.distribution.service;
+
+import com.hwgi.autocert.certificate.distribution.config.DistributionProperties;
+import com.hwgi.autocert.certificate.distribution.ssh.SshClient;
+import com.hwgi.autocert.domain.model.Certificate;
+import com.hwgi.autocert.domain.model.Deployment;
+import com.hwgi.autocert.domain.model.DeploymentStatus;
+import com.hwgi.autocert.domain.model.Server;
+import com.hwgi.autocert.domain.repository.DeploymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.schmizz.sshj.SSHClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 인증서 배포 서비스
+ * SSH/SFTP를 통한 서버 배포 구현
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CertificateDistributionService {
+
+    private final SshClient sshClient;
+    private final DeploymentRepository deploymentRepository;
+    private final DistributionProperties properties;
+
+    /**
+     * 서버에 인증서 배포
+     *
+     * @param certificate 배포할 인증서
+     * @param decryptedPrivateKey 복호화된 개인키
+     * @return 배포 성공 여부
+     */
+    @Transactional
+    public boolean deploy(Certificate certificate, String decryptedPrivateKey) {
+        Server server = certificate.getServer();
+
+        if (server == null) {
+            log.error("Certificate {} has no associated server", certificate.getId());
+            return false;
+        }
+
+        log.info("Starting deployment of certificate {} to server {} ({}:{})",
+                certificate.getId(),
+                server.getName(),
+                server.getIpAddress(),
+                server.getPort());
+
+        long startTime = System.currentTimeMillis();
+        Deployment deployment = createDeployment(certificate, server, DeploymentStatus.IN_PROGRESS);
+
+        SSHClient ssh = null;
+        try {
+            // 1. SSH 연결
+            ssh = connectWithRetry(server);
+
+            // 2. 배포 경로 결정
+            String deployPath = server.getDeployPath() != null
+                ? server.getDeployPath()
+                : properties.getSsh().getDefaultCertPath();
+
+            String certPath = deployPath + "/" + certificate.getDomain() + ".crt";
+            String keyPath = deployPath + "/" + certificate.getDomain() + ".key";
+            String chainPath = deployPath + "/" + certificate.getDomain() + "-chain.crt";
+
+            // 3. 인증서 파일 업로드
+            log.info("Uploading certificate files to {}", deployPath);
+            sshClient.uploadContent(ssh, certificate.getCertificatePem(), certPath);
+            sshClient.uploadContent(ssh, decryptedPrivateKey, keyPath);
+
+            if (certificate.getChainPem() != null && !certificate.getChainPem().isEmpty()) {
+                sshClient.uploadContent(ssh, certificate.getChainPem(), chainPath);
+            }
+
+            // 4. 배포 성공 기록
+            long duration = System.currentTimeMillis() - startTime;
+            updateDeploymentStatus(deployment, DeploymentStatus.SUCCESS, deployPath,
+                "Successfully deployed certificate files", duration);
+
+            log.info("Certificate {} deployed successfully to server {} in {}ms",
+                    certificate.getId(), server.getName(), duration);
+
+            return true;
+
+        } catch (Exception e) {
+            log.error("Failed to deploy certificate {} to server {}: {}",
+                    certificate.getId(), server.getName(), e.getMessage(), e);
+
+            long duration = System.currentTimeMillis() - startTime;
+            updateDeploymentStatus(deployment, DeploymentStatus.FAILED, null,
+                "Deployment failed: " + e.getMessage(), duration);
+
+            return false;
+
+        } finally {
+            sshClient.disconnect(ssh);
+        }
+    }
+
+    /**
+     * 재시도 로직을 포함한 SSH 연결
+     *
+     * @param server 서버
+     * @return SSH 클라이언트
+     */
+    private SSHClient connectWithRetry(Server server) throws Exception {
+        int maxRetries = properties.getSsh().getMaxRetries();
+        int retryDelay = properties.getSsh().getRetryDelay();
+
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                log.debug("SSH connection attempt {}/{} to {}", attempt, maxRetries, server.getIpAddress());
+
+                return sshClient.connect(
+                    server.getIpAddress(),
+                    server.getPort(),
+                    server.getUsername(),
+                    server.getPassword()
+                );
+
+            } catch (Exception e) {
+                lastException = e;
+                log.warn("SSH connection attempt {}/{} failed: {}", attempt, maxRetries, e.getMessage());
+
+                if (attempt < maxRetries) {
+                    Thread.sleep(retryDelay * attempt); // Exponential backoff
+                }
+            }
+        }
+
+        throw new Exception("Failed to connect after " + maxRetries + " attempts", lastException);
+    }
+
+    /**
+     * 배포 이력 생성
+     *
+     * @param certificate 인증서
+     * @param server 서버
+     * @param status 상태
+     * @return 배포 이력
+     */
+    private Deployment createDeployment(Certificate certificate, Server server, DeploymentStatus status) {
+        Deployment deployment = Deployment.builder()
+                .certificate(certificate)
+                .server(server)
+                .deployedAt(LocalDateTime.now())
+                .status(status)
+                .build();
+
+        return deploymentRepository.save(deployment);
+    }
+
+    /**
+     * 배포 상태 업데이트
+     *
+     * @param deployment 배포 이력
+     * @param status 상태
+     * @param deploymentPath 배포 경로
+     * @param message 메시지
+     * @param durationMs 소요 시간
+     */
+    private void updateDeploymentStatus(Deployment deployment, DeploymentStatus status,
+                                       String deploymentPath, String message, long durationMs) {
+        deployment.setStatus(status);
+        deployment.setDeploymentPath(deploymentPath);
+        deployment.setMessage(message);
+        deployment.setDurationMs(durationMs);
+        deploymentRepository.save(deployment);
+    }
+
+    /**
+     * 배포 준비 상태 확인
+     *
+     * @param certificate 확인할 인증서
+     * @return 배포 가능 여부
+     */
+    public boolean isReadyForDeployment(Certificate certificate) {
+        if (certificate == null) {
+            log.warn("Certificate is null");
+            return false;
+        }
+
+        if (certificate.getServer() == null) {
+            log.warn("Certificate {} has no associated server", certificate.getId());
+            return false;
+        }
+
+        if (certificate.getCertificatePem() == null || certificate.getCertificatePem().isEmpty()) {
+            log.warn("Certificate {} has no certificate PEM", certificate.getId());
+            return false;
+        }
+
+        if (certificate.getPrivateKeyPem() == null || certificate.getPrivateKeyPem().isEmpty()) {
+            log.warn("Certificate {} has no private key PEM", certificate.getId());
+            return false;
+        }
+
+        Server server = certificate.getServer();
+        if (server.getIpAddress() == null || server.getIpAddress().isEmpty()) {
+            log.warn("Server {} has no IP address", server.getId());
+            return false;
+        }
+
+        if (server.getUsername() == null || server.getUsername().isEmpty()) {
+            log.warn("Server {} has no username", server.getId());
+            return false;
+        }
+
+        if (server.getPassword() == null || server.getPassword().isEmpty()) {
+            log.warn("Server {} has no password", server.getId());
+            return false;
+        }
+
+        log.debug("Certificate {} is ready for deployment", certificate.getId());
+        return true;
+    }
+}

--- a/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/ssh/SshClient.java
+++ b/certificate-manager/src/main/java/com/hwgi/autocert/certificate/distribution/ssh/SshClient.java
@@ -1,0 +1,159 @@
+package com.hwgi.autocert.certificate.distribution.ssh;
+
+import com.hwgi.autocert.certificate.distribution.config.DistributionProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.xfer.FileSystemFile;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * SSH/SFTP 클라이언트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SshClient {
+
+    private final DistributionProperties properties;
+
+    /**
+     * SSH 연결 생성
+     *
+     * @param host 호스트
+     * @param port 포트
+     * @param username 사용자명
+     * @param password 비밀번호
+     * @return SSH 클라이언트
+     */
+    public SSHClient connect(String host, int port, String username, String password) throws IOException {
+        log.debug("Connecting to SSH server: {}@{}:{}", username, host, port);
+
+        SSHClient ssh = new SSHClient();
+        ssh.addHostKeyVerifier(new PromiscuousVerifier()); // Production에서는 실제 호스트 키 검증 필요
+        ssh.setTimeout(properties.getSsh().getTimeout());
+
+        ssh.connect(host, port);
+        ssh.authPassword(username, password);
+
+        log.info("SSH connection established: {}@{}:{}", username, host, port);
+        return ssh;
+    }
+
+    /**
+     * 파일 업로드
+     *
+     * @param ssh SSH 클라이언트
+     * @param localFilePath 로컬 파일 경로
+     * @param remoteFilePath 원격 파일 경로
+     */
+    public void uploadFile(SSHClient ssh, String localFilePath, String remoteFilePath) throws IOException {
+        log.debug("Uploading file: {} -> {}", localFilePath, remoteFilePath);
+
+        try (SFTPClient sftp = ssh.newSFTPClient()) {
+            // 원격 디렉토리 생성
+            String remoteDir = remoteFilePath.substring(0, remoteFilePath.lastIndexOf('/'));
+            createRemoteDirectory(sftp, remoteDir);
+
+            // 파일 업로드
+            sftp.put(new FileSystemFile(localFilePath), remoteFilePath);
+
+            // 파일 권한 설정 (600 - owner read/write only)
+            sftp.chmod(remoteFilePath, 0600);
+
+            log.info("File uploaded successfully: {}", remoteFilePath);
+        }
+    }
+
+    /**
+     * 문자열 내용을 원격 파일로 업로드
+     *
+     * @param ssh SSH 클라이언트
+     * @param content 파일 내용
+     * @param remoteFilePath 원격 파일 경로
+     */
+    public void uploadContent(SSHClient ssh, String content, String remoteFilePath) throws IOException {
+        log.debug("Uploading content to: {}", remoteFilePath);
+
+        // 임시 파일 생성
+        Path tempFile = Files.createTempFile("autocert-", ".tmp");
+        try {
+            Files.writeString(tempFile, content);
+            uploadFile(ssh, tempFile.toString(), remoteFilePath);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+
+        log.info("Content uploaded successfully: {}", remoteFilePath);
+    }
+
+    /**
+     * 원격 디렉토리 생성
+     *
+     * @param sftp SFTP 클라이언트
+     * @param remotePath 원격 디렉토리 경로
+     */
+    private void createRemoteDirectory(SFTPClient sftp, String remotePath) throws IOException {
+        try {
+            sftp.statExistence(remotePath);
+            log.debug("Remote directory already exists: {}", remotePath);
+        } catch (IOException e) {
+            log.debug("Creating remote directory: {}", remotePath);
+            sftp.mkdirs(remotePath);
+        }
+    }
+
+    /**
+     * 명령 실행
+     *
+     * @param ssh SSH 클라이언트
+     * @param command 실행할 명령
+     * @return 명령 출력
+     */
+    public String executeCommand(SSHClient ssh, String command) throws IOException {
+        log.debug("Executing command: {}", command);
+
+        try (var session = ssh.startSession();
+             var cmd = session.exec(command)) {
+
+            String output = new String(cmd.getInputStream().readAllBytes());
+            String error = new String(cmd.getErrorStream().readAllBytes());
+
+            cmd.join(properties.getSsh().getTimeout(), java.util.concurrent.TimeUnit.MILLISECONDS);
+
+            int exitStatus = cmd.getExitStatus();
+
+            if (exitStatus != 0) {
+                log.warn("Command failed with exit code {}: {}", exitStatus, error);
+                throw new IOException("Command execution failed: " + error);
+            }
+
+            log.info("Command executed successfully: {}", command);
+            return output;
+        }
+    }
+
+    /**
+     * 연결 종료
+     *
+     * @param ssh SSH 클라이언트
+     */
+    public void disconnect(SSHClient ssh) {
+        if (ssh != null && ssh.isConnected()) {
+            try {
+                ssh.disconnect();
+                log.debug("SSH connection closed");
+            } catch (IOException e) {
+                log.warn("Error closing SSH connection", e);
+            }
+        }
+    }
+}

--- a/certificate-manager/src/main/resources/application.yml
+++ b/certificate-manager/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+autocert:
+  distribution:
+    ssh:
+      timeout: 30000          # SSH 연결 타임아웃 (30초)
+      max-retries: 3          # 최대 재시도 횟수
+      retry-delay: 1000       # 재시도 대기 시간 (1초)
+      port: 22                # SSH 포트
+      default-cert-path: /etc/ssl/certs    # 기본 인증서 경로
+      default-key-path: /etc/ssl/private   # 기본 개인키 경로

--- a/domain/src/main/java/com/hwgi/autocert/domain/model/Certificate.java
+++ b/domain/src/main/java/com/hwgi/autocert/domain/model/Certificate.java
@@ -22,6 +22,10 @@ public class Certificate {
     @Column(nullable = false, unique = true)
     private String domain;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "server_id", nullable = false)
+    private Server server;
+
     @Column(name = "issued_at")
     private LocalDateTime issuedAt;
 
@@ -53,6 +57,10 @@ public class Certificate {
     @Builder.Default
     @Column(nullable = false)
     private Integer alertDaysBeforeExpiry = 7;
+
+    @Builder.Default
+    @Column(name = "auto_deploy", nullable = false)
+    private Boolean autoDeploy = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/domain/src/main/java/com/hwgi/autocert/domain/model/Deployment.java
+++ b/domain/src/main/java/com/hwgi/autocert/domain/model/Deployment.java
@@ -1,18 +1,20 @@
 package com.hwgi.autocert.domain.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
+/**
+ * 배포 이력 엔티티
+ */
 @Entity
 @Table(name = "deployments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Deployment {
 
     @Id
@@ -27,8 +29,30 @@ public class Deployment {
     @JoinColumn(name = "server_id", nullable = false)
     private Server server;
 
-    @Column(name = "deployed_at")
+    @Column(name = "deployed_at", nullable = false)
     private LocalDateTime deployedAt;
 
-    // Getters and Setters
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DeploymentStatus status;
+
+    @Column(name = "deployment_path")
+    private String deploymentPath;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "duration_ms")
+    private Long durationMs;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        if (deployedAt == null) {
+            deployedAt = LocalDateTime.now();
+        }
+    }
 }

--- a/domain/src/main/java/com/hwgi/autocert/domain/model/DeploymentStatus.java
+++ b/domain/src/main/java/com/hwgi/autocert/domain/model/DeploymentStatus.java
@@ -1,0 +1,26 @@
+package com.hwgi.autocert.domain.model;
+
+/**
+ * 배포 상태
+ */
+public enum DeploymentStatus {
+    /**
+     * 배포 성공
+     */
+    SUCCESS,
+    
+    /**
+     * 배포 실패
+     */
+    FAILED,
+    
+    /**
+     * 배포 진행 중
+     */
+    IN_PROGRESS,
+    
+    /**
+     * 배포 롤백됨
+     */
+    ROLLED_BACK
+}

--- a/domain/src/main/java/com/hwgi/autocert/domain/repository/DeploymentRepository.java
+++ b/domain/src/main/java/com/hwgi/autocert/domain/repository/DeploymentRepository.java
@@ -1,0 +1,50 @@
+package com.hwgi.autocert.domain.repository;
+
+import com.hwgi.autocert.domain.model.Deployment;
+import com.hwgi.autocert.domain.model.DeploymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 배포 이력 Repository
+ */
+@Repository
+public interface DeploymentRepository extends JpaRepository<Deployment, Long> {
+
+    /**
+     * 인증서별 배포 이력 조회
+     */
+    Page<Deployment> findByCertificateIdOrderByDeployedAtDesc(Long certificateId, Pageable pageable);
+
+    /**
+     * 서버별 배포 이력 조회
+     */
+    Page<Deployment> findByServerIdOrderByDeployedAtDesc(Long serverId, Pageable pageable);
+
+    /**
+     * 상태별 배포 이력 조회
+     */
+    Page<Deployment> findByStatus(DeploymentStatus status, Pageable pageable);
+
+    /**
+     * 특정 기간 내 배포 이력 조회
+     */
+    @Query("SELECT d FROM Deployment d WHERE d.deployedAt BETWEEN :startDate AND :endDate ORDER BY d.deployedAt DESC")
+    List<Deployment> findDeploymentsBetween(@Param("startDate") LocalDateTime startDate, 
+                                            @Param("endDate") LocalDateTime endDate);
+
+    /**
+     * 최근 배포 이력 조회 (인증서 + 서버)
+     */
+    @Query("SELECT d FROM Deployment d WHERE d.certificate.id = :certificateId AND d.server.id = :serverId ORDER BY d.deployedAt DESC")
+    List<Deployment> findLatestDeployment(@Param("certificateId") Long certificateId, 
+                                         @Param("serverId") Long serverId, 
+                                         Pageable pageable);
+}

--- a/domain/src/main/resources/db/migration/V5__Add_server_id_to_certificates.sql
+++ b/domain/src/main/resources/db/migration/V5__Add_server_id_to_certificates.sql
@@ -1,0 +1,45 @@
+-- Add server_id foreign key to certificates table
+
+-- Step 1: Add server_id column (nullable first to allow existing records)
+ALTER TABLE certificates
+    ADD COLUMN server_id BIGINT;
+
+-- Step 2: If there are existing certificates without a server, create a default server
+-- and assign it to existing certificates
+DO $$
+DECLARE
+    default_server_id BIGINT;
+BEGIN
+    -- Check if there are any certificates without a server
+    IF EXISTS (SELECT 1 FROM certificates WHERE server_id IS NULL) THEN
+        -- Check if a default server exists
+        SELECT id INTO default_server_id FROM servers LIMIT 1;
+        
+        -- If no server exists, create a default one
+        IF default_server_id IS NULL THEN
+            INSERT INTO servers (name, ip_address, port, web_server_type, username, password, deploy_path, created_at, updated_at)
+            VALUES ('Default Server', 'localhost', 22, 'NGINX', 'root', '', '/etc/ssl/certs', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            RETURNING id INTO default_server_id;
+        END IF;
+        
+        -- Assign the default server to all certificates without a server
+        UPDATE certificates
+        SET server_id = default_server_id
+        WHERE server_id IS NULL;
+    END IF;
+END $$;
+
+-- Step 3: Make server_id NOT NULL
+ALTER TABLE certificates
+    ALTER COLUMN server_id SET NOT NULL;
+
+-- Step 4: Add foreign key constraint
+ALTER TABLE certificates
+    ADD CONSTRAINT fk_certificates_server
+    FOREIGN KEY (server_id) REFERENCES servers(id);
+
+-- Step 5: Create index for foreign key
+CREATE INDEX idx_certificates_server_id ON certificates(server_id);
+
+-- Add comment
+COMMENT ON COLUMN certificates.server_id IS 'Reference to the server where this certificate is deployed';

--- a/domain/src/main/resources/db/migration/V6__Add_auto_deploy_to_certificates.sql
+++ b/domain/src/main/resources/db/migration/V6__Add_auto_deploy_to_certificates.sql
@@ -1,0 +1,5 @@
+-- Add auto_deploy column to certificates table
+ALTER TABLE certificates
+ADD COLUMN auto_deploy BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN certificates.auto_deploy IS '서버에 자동 배포 여부 (갱신 시에도 적용)';

--- a/domain/src/main/resources/db/migration/V7__Update_deployments_table.sql
+++ b/domain/src/main/resources/db/migration/V7__Update_deployments_table.sql
@@ -1,0 +1,43 @@
+-- Update deployments table (V1에서 기본 구조로 생성됨)
+-- Add new columns
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS status VARCHAR(20);
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS deployment_path VARCHAR(500);
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS message TEXT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS duration_ms BIGINT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+-- Update existing deployed_at column to NOT NULL (기존 데이터가 있으면 현재 시간으로 설정)
+UPDATE deployments SET deployed_at = CURRENT_TIMESTAMP WHERE deployed_at IS NULL;
+ALTER TABLE deployments ALTER COLUMN deployed_at SET NOT NULL;
+
+-- Update status column to NOT NULL (기존 데이터가 있으면 'SUCCESS'로 설정)
+UPDATE deployments SET status = 'SUCCESS' WHERE status IS NULL;
+ALTER TABLE deployments ALTER COLUMN status SET NOT NULL;
+
+-- Add foreign key constraints if not exists
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_deployments_certificate') THEN
+        ALTER TABLE deployments ADD CONSTRAINT fk_deployments_certificate
+            FOREIGN KEY (certificate_id) REFERENCES certificates(id) ON DELETE CASCADE;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_deployments_server') THEN
+        ALTER TABLE deployments ADD CONSTRAINT fk_deployments_server
+            FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+-- Create additional indexes (V1에 일부 인덱스는 이미 있음)
+CREATE INDEX IF NOT EXISTS idx_deployments_deployed_at ON deployments(deployed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_deployments_status ON deployments(status);
+
+-- Add comments
+COMMENT ON TABLE deployments IS '인증서 배포 이력';
+COMMENT ON COLUMN deployments.certificate_id IS '배포된 인증서 ID';
+COMMENT ON COLUMN deployments.server_id IS '배포 대상 서버 ID';
+COMMENT ON COLUMN deployments.deployed_at IS '배포 시각';
+COMMENT ON COLUMN deployments.status IS '배포 상태 (SUCCESS, FAILED, IN_PROGRESS, ROLLED_BACK)';
+COMMENT ON COLUMN deployments.deployment_path IS '배포 경로';
+COMMENT ON COLUMN deployments.message IS '배포 메시지 또는 오류 메시지';
+COMMENT ON COLUMN deployments.duration_ms IS '배포 소요 시간 (밀리초)';


### PR DESCRIPTION
## 개요
인증서 수정 엔드포인트에서 모든 필드를 수정할 수 있도록 확장하고, distribution-service 모듈을 certificate-manager로 통합하여 모듈 구조를 최적화했습니다.

Closes #4

## 변경 사항

### 1. 인증서 수정 API 확장 ✨
기존에는 `admin`, `alertDaysBeforeExpiry`, `autoDeploy` 3개 필드만 수정 가능했으나, 이제 모든 필드를 수정할 수 있습니다.

**추가된 수정 가능 필드:**
- `domain` - 도메인 이름
- `serverId` - 서버 ID  
- `issuedAt` - 발급 일시
- `expiresAt` - 만료 일시
- `status` - 인증서 상태
- `certificatePem` - 인증서 PEM 데이터
- `privateKeyPem` - 개인키 PEM 데이터
- `chainPem` - 체인 PEM 데이터
- `password` - 인증서 비밀번호

**변경된 파일:**
- `api/src/main/java/com/hwgi/autocert/api/dto/request/CertificateUpdateRequest.java`
- `api/src/main/java/com/hwgi/autocert/api/controller/CertificateController.java`
- `certificate-manager/src/main/java/com/hwgi/autocert/certificate/service/CertificateService.java`

### 2. 모듈 구조 최적화 🏗️
distribution-service를 certificate-manager로 통합하여 아키텍처를 간소화했습니다.

**Before:**
```
api
 ├─> certificate-manager
 ├─> distribution-service  ❌
 └─> domain
```

**After:**
```
api
 ├─> certificate-manager (인증서 관리 + 배포 통합) ✅
 └─> domain
```

**이동된 코드:**
- `DistributionProperties` → `certificate-manager/distribution/config/`
- `CertificateDistributionService` → `certificate-manager/distribution/service/`
- `SshClient` → `certificate-manager/distribution/ssh/`

### 3. 아키텍처 개선 🎯

**순환 의존성 해결:**
- certificate-manager가 api 모듈의 DTO를 참조하면 순환 의존성 발생
- 해결: 서비스 메서드를 13개 개별 파라미터로 변경

**배포 기능 응집도 향상:**
- 인증서 관리와 배포는 밀접하게 연관된 기능
- 하나의 모듈로 통합하여 코드 응집도 향상
- 불필요한 모듈 간 의존성 제거

### 4. 문서 및 설정 업데이트 📝
- `CLAUDE.md` - 모듈 구조 설명 업데이트
- `README.md` - 프로젝트 구조 반영  
- `PROJECT_STRUCTURE.md` - 상세 모듈 구조 업데이트
- `.dockerignore`, `Dockerfile` 최적화

## API 사용 예시

### 부분 업데이트 (Partial Update)
수정하고 싶은 필드만 전송하면 됩니다.

```bash
# 관리자와 알림 일수만 수정
PUT /api/v1/certificates/1
{
  "admin": "new-admin@example.com",
  "alertDaysBeforeExpiry": 14
}

# 도메인과 서버 변경
PUT /api/v1/certificates/1
{
  "domain": "new-domain.com",
  "serverId": 2
}

# 인증서 상태만 변경
PUT /api/v1/certificates/1
{
  "status": "REVOKED"
}
```

## 기술적 고려사항

### 레이어드 아키텍처 원칙 준수
- 상위 계층(api)이 하위 계층(certificate-manager)을 의존 ✅
- 하위 계층이 상위 계층을 의존하지 않음 ✅
- 순환 의존성 방지 ✅

### 빌드 성능 향상
- 모듈 수 감소: 5개 → 4개
- 의존성 트리 단순화
- 빌드 시간 단축

## 테스트

### 빌드 테스트
```bash
./gradlew clean build -x test
```
✅ BUILD SUCCESSFUL in 11s

### 변경된 파일 통계
- 22 files changed
- 974 insertions(+)
- 249 deletions(-)

## 체크리스트
- [x] 코드 작성 완료
- [x] 빌드 테스트 통과
- [x] 모듈 의존성 검증
- [x] 문서 업데이트
- [x] 커밋 메시지 작성
- [x] 이슈 생성 (#4)

## 후속 작업 제안
- [ ] 인증서 수정 API 통합 테스트 추가
- [ ] Swagger 문서에서 각 필드 상세 설명 보강
- [ ] 인증서 수정 시 유효성 검증 로직 강화
- [ ] 배포 기능 단위 테스트 추가

## 관련 이슈
- Closes #4

## 스크린샷 / 데모
N/A (백엔드 API 변경)

---

**Commit:** 6b50ff1
**Branch:** #3-deploy-certificate-to-server → main